### PR TITLE
FOGL-9773 run tests with valgrind along with detailed report

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,6 @@
 timestamps {
     node("ubuntu18-agent") {
+        def IS_MEMORY_LEAKAGE = 'FALSE'
         catchError {
             checkout scm
             dir_exists = sh (
@@ -28,16 +29,32 @@ timestamps {
             }   
 
             try { 
-                stage("Run Tests"){
+                stage("Run Tests") {
                     echo "Executing tests..."
                     sh '''
                         export FLEDGE_ROOT=$HOME/fledge
-                        cd tests && cmake . && make && ./RunTests --gtest_output=xml:test_output.xml
+                        cd tests && cmake . && make -j$(nproc)
+                        valgrind -v --leak-check=full ./RunTests --gtest_output=xml:test_output.xml > valgrind_report.log 2>&1
                     '''
+                    def leakDetected = sh(
+                        script: "grep -q '^==[0-9]*==    definitely lost: [1-9][0-9,]* bytes' tests/valgrind_report.log && echo Y || echo N",
+                        returnStdout: true
+                    ).trim()
+
+                    if (leakDetected == 'Y') {
+                        IS_MEMORY_LEAKAGE = 'TRUE'
+                        echo "❗ Memory leaks detected!"
+                        sh '''
+                            grep -A 4 '^==[0-9]*== HEAP SUMMARY:' tests/valgrind_report.log || true
+                            grep -A 8 '^==[0-9]*== LEAK SUMMARY:' tests/valgrind_report.log || true
+                        '''
+                        currentBuild.result = 'FAILURE'
+                    } else {
+                        echo "✅ No memory leaks detected."
+                    }
                     echo "Done."
                 }
             } catch (e) {
-                result = "TESTS FAILED" 
                 currentBuild.result = 'FAILURE'
                 echo "Tests failed!"
             }
@@ -45,9 +62,11 @@ timestamps {
             try {
                 stage("Publish Test Report"){
                     junit "tests/test_output.xml"
+                    if (IS_MEMORY_LEAKAGE == 'TRUE') {
+                        archiveArtifacts artifacts: 'tests/valgrind_report.log'
+                    }
                 }
             } catch (e) {
-                result = "TEST REPORT GENERATION FAILED"
                 currentBuild.result = 'FAILURE'
                 echo "Failed to generate test reports!"
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,8 +33,8 @@ timestamps {
                     echo "Executing tests..."
                     sh '''
                         export FLEDGE_ROOT=$HOME/fledge
-                        cd tests && cmake . && make -j$(nproc)
-                        valgrind -v --leak-check=full ./RunTests --gtest_output=xml:test_output.xml > valgrind_report.log 2>&1
+                        cd tests && cmake . && make -j$(nproc) && \
+                        valgrind -v --leak-check=full ./RunTests --gtest_output=xml:test_output.xml 2>&1 | tee valgrind_report.log
                     '''
                     def leakDetected = sh(
                         script: "grep -q '^==[0-9]*==    definitely lost: [1-9][0-9,]* bytes' tests/valgrind_report.log && echo Y || echo N",


### PR DESCRIPTION
If a memory leak is identified as definitely lost, a Valgrind report will be generated in the CI, and the build run will be marked as failed.

